### PR TITLE
Raise json dependency version to be compatible with Ruby 2.4.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    json (1.8.1)
+    json (2.0.2)
     mini_portile (0.5.2)
     newrelic_plugin (1.3.1)
       json


### PR DESCRIPTION
Was able to successfully `bundle install` with this dependency version raise.  This is necessary to raise `nitro-web`'s Ruby version to 2.4.3.

Reference: 
https://github.com/flori/json/blob/master/CHANGES.md#2015-09-11-200 & 
https://github.com/tamaloa/newrelic_passenger_plugin/commit/02f2f6b4d092aefcc6bfe5d6afced0dc56e2ac8c

Associated PRs:

https://github.com/powerhome/puppet-ctrl/pull/1135 &
https://github.com/powerhome/nitro-web/pull/7729
